### PR TITLE
chore(docs): update hcl example block

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ module slackbot {
   api_description = "My Slack REST API"
   api_name        = "<my-api>"
   api_stage_name  = "<my-api-stage>"
-  api_name        = "<my-app-name>"
+  app_name        = "<my-app-name>"
   secret_name     = module.slackbot_secrets.secret_name
   kms_key_id      = module.slackbot_secrets.kms_key_id
 }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ module slackbot {
   api_description = "My Slack REST API"
   api_name        = "<my-api>"
   api_stage_name  = "<my-api-stage>"
-  secret_arn      = module.slackbot_secrets.secret_arn
+  api_name        = "<my-app-name>"
+  secret_name     = module.slackbot_secrets.secret_name
   kms_key_id      = module.slackbot_secrets.kms_key_id
 }
 ```


### PR DESCRIPTION
Found this as I was setting up a new project:

* s/secret_arn/secret_name
* `app_name` is now required